### PR TITLE
Make code clippy-clean

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,5 +12,5 @@ mod tests {
 
 #[wasm_bindgen]
 pub fn is_computer_on() -> bool {
-    return true;
+    true
 }


### PR DESCRIPTION
A critical infrastructure crate such as this should leverage Rust's
static analysis tools to the greatest extent possible, I think.